### PR TITLE
Fix invalid TCA configuration and a misbehavior with the poster image in firefox

### DIFF
--- a/Classes/Resource/Rendering/VideoTagRenderer.php
+++ b/Classes/Resource/Rendering/VideoTagRenderer.php
@@ -161,7 +161,12 @@ class VideoTagRenderer extends \TYPO3\CMS\Core\Resource\Rendering\VideoTagRender
             $sourceParams[] = $end;
         }
 
-        $sourceTime = sprintf('#t=%s', implode(',', $sourceParams));
+        // Only add the time parameter if they are actually set to something other than 0.
+        // Otherwise firefox will show the first video frame from that timestamp instead of the poster image.
+        $sourceTime = '';
+        if ($start !== 0 || $end !== 0) {
+            $sourceTime = sprintf('#t=%s', implode(',', $sourceParams));
+        }
 
         $noVideoSupport = sprintf('<p>%s <a href="%s">%s</a></p>',
             self::translate('LLL:EXT:video_vtt/Resources/Private/Language/locallang.xlf:no_video_support'),

--- a/Classes/Resource/Rendering/VideoTagRenderer.php
+++ b/Classes/Resource/Rendering/VideoTagRenderer.php
@@ -161,8 +161,6 @@ class VideoTagRenderer extends \TYPO3\CMS\Core\Resource\Rendering\VideoTagRender
             $sourceParams[] = $end;
         }
 
-        // Only add the time parameter if they are actually set to something other than 0.
-        // Otherwise firefox will show the first video frame from that timestamp instead of the poster image.
         $sourceTime = '';
         if ($start !== 0 || $end !== 0) {
             $sourceTime = sprintf('#t=%s', implode(',', $sourceParams));

--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -12,11 +12,12 @@ call_user_func(function ($_EXTKEY = 'video_vtt', $table = 'sys_file_metadata'): 
                 'type' => 'file',
                 'allowed' => 'vtt',
                 'overrideChildTca' => [
-                    'columns' => [
-                        'link' => false,
-                        'description' => false,
-                        'alternative' => false,
-                        'title' => false,
+                    'types' => [
+                        \TYPO3\CMS\Core\Resource\FileType::TEXT->value => [
+                            'showitem' => '
+                                    --palette--;;trackOverlayPalette,
+                                    --palette--;;filePalette',
+                        ],
                     ],
                 ],
             ],
@@ -36,14 +37,9 @@ call_user_func(function ($_EXTKEY = 'video_vtt', $table = 'sys_file_metadata'): 
                     'types' => [
                         \TYPO3\CMS\Core\Resource\FileType::IMAGE->value => [
                             'showitem' => '
-                                    --palette--;;imageoverlayPalette,
+                                    --palette--;;posterImageOverlayPalette,
                                     --palette--;;filePalette',
                         ],
-                    ],
-                    'columns' => [
-                        'link' => false,
-                        'description' => false,
-                        'title' => false,
                     ],
                 ],
             ],

--- a/Configuration/TCA/Overrides/sys_file_reference.php
+++ b/Configuration/TCA/Overrides/sys_file_reference.php
@@ -163,14 +163,9 @@ call_user_func(function ($_EXTKEY = 'video_vtt', $table = 'sys_file_reference'):
                     'types' => [
                         \TYPO3\CMS\Core\Resource\FileType::IMAGE->value => [
                             'showitem' => '
-                                    --palette--;;imageoverlayPalette,
+                                    --palette--;;posterImageOverlayPalette,
                                     --palette--;;filePalette',
                         ],
-                    ],
-                    'columns' => [
-                        'link' => false,
-                        'description' => false,
-                        'title' => false,
                     ],
                 ],
             ],
@@ -238,7 +233,11 @@ call_user_func(function ($_EXTKEY = 'video_vtt', $table = 'sys_file_reference'):
          --linebreak--,autoplay,mute,loop,
          --linebreak--,controls';
 
-    $GLOBALS['TCA'][$table]['palettes']['basicoverlayPalette']['showitem']
-        = 'title,description,
-    --linebreak--,track_default,--linebreak--,track_label,track_language,track_type';
+    $GLOBALS['TCA'][$table]['palettes']['trackOverlayPalette']['showitem']
+        = 'track_default,--linebreak--,track_label,track_language,track_type';
+
+    $GLOBALS['TCA'][$table]['palettes']['posterImageOverlayPalette'] = [
+        'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:sys_file_reference.imageoverlayPalette',
+        'showitem' => 'alternative,--linebreak--,crop',
+    ];
 });


### PR DESCRIPTION
Hello, I recently used this extension in a project with TYPO3 13.4.31, and came across two minor issues:

1) **Invalid TCA configuration in some IRRE file fields, causing errors in backend**

   The TCA configuration for the fields `tracks` and `poster` of the table `sys_file_metadata`, and the field `poster` in `sys_file_reference` set some child field configurations in `['overrideChildTca']['config']` to `false`. I assume the intention behind this was to not show these fields in the backend, but TYPO3's form engine does not really seem to like this. When I attempt to expand one of the file reference records in the backend, I only get an 'Error undefined' ajax error.

   I solved this issue by creating custom palettes instead, that do not contain these fields.
2) **Firefox shows the first video frame instead of the poster image**

   This is more a browser-specific issue (maybe even version-specific, definitely happened in version 150.0.3 for me), as it works in Chromium correctly. The problem is that a `#t=0` is appended to the video source URL, even if both `start_time` and `end_time` are set to 0. In that case, firefox seems to only show the poster image until the first video frame is fetched, and then replaces the poster image with that frame.

   I fixed this by only adding that timestamp hash, if `start_time` or `end_time` are actually set to anything else than 0.