### PR TITLE
[fix] Fix attribute handling in VideoTagRenderer

### DIFF
--- a/Classes/Resource/Rendering/VideoTagRenderer.php
+++ b/Classes/Resource/Rendering/VideoTagRenderer.php
@@ -55,7 +55,7 @@ class VideoTagRenderer extends \TYPO3\CMS\Core\Resource\Rendering\VideoTagRender
 
         $attributes = [];
         if ($options->getAdditionalAttributes() !== []) {
-            $attributes[] = GeneralUtility::implodeAttributes($options['additionalAttributes'], true, true);
+            $attributes[] = GeneralUtility::implodeAttributes($options->getAdditionalAttributes(), true, true);
         }
 
         if ($options->getData() !== []) {


### PR DESCRIPTION
WIth 2.8.7 the options has been changed from array to object. While the AudioTagRenderer correctly has been changed to the object notation the VideoTagRenderer kept the array notation.

Currently the frontend rendering fails with:

(1/1) Error
Cannot use object of type TRAW\VideoVtt\Options\Options as array

in /var/www/html/vendor/traw/video-vtt/Classes/Resource/Rendering/VideoTagRenderer.php line 58

This commit fixes the VideoTagRenderer $options usage.

Commit 18a683291bfe4f496db6a0c2705a24c915fc5052 changed from array to object